### PR TITLE
Оптимизации времени работы Smuggler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = '1.1.6'
+  version = '1.1.7'
   group = 'com.joom.smuggler'
 
   ext {

--- a/smuggler-compiler/src/main/java/com/joom/smuggler/compiler/SmugglerCompiler.kt
+++ b/smuggler-compiler/src/main/java/com/joom/smuggler/compiler/SmugglerCompiler.kt
@@ -8,13 +8,13 @@ import io.michaelrocks.grip.Grip
 import io.michaelrocks.grip.GripFactory
 import io.michaelrocks.grip.classes
 import io.michaelrocks.grip.mirrors.ClassMirror
+import java.io.Closeable
 import java.io.File
 
 class SmugglerCompiler private constructor(
   private val grip: Grip,
   private val adapters: Collection<File>
-) {
-
+) : Closeable {
   private val environment = GenerationEnvironment(grip)
   private val factory = ValueAdapterFactory.from(grip, adapters)
 
@@ -53,6 +53,10 @@ class SmugglerCompiler private constructor(
       .where(isAutoParcelable())
       .execute()
       .values
+  }
+
+  override fun close() {
+    grip.close()
   }
 
   companion object {

--- a/smuggler-compiler/src/main/java/com/joom/smuggler/compiler/SmugglerCompiler.kt
+++ b/smuggler-compiler/src/main/java/com/joom/smuggler/compiler/SmugglerCompiler.kt
@@ -10,6 +10,10 @@ import io.michaelrocks.grip.classes
 import io.michaelrocks.grip.mirrors.ClassMirror
 import java.io.Closeable
 import java.io.File
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.util.zip.ZipFile
+import kotlin.io.path.writeBytes
 
 class SmugglerCompiler private constructor(
   private val grip: Grip,
@@ -19,20 +23,14 @@ class SmugglerCompiler private constructor(
   private val factory = ValueAdapterFactory.from(grip, adapters)
 
   fun compile(input: File, output: File) {
-    for (parcelable in findAutoParcelableClasses(listOf(input))) {
-      val spec = AutoParcelableClassSpecFactory.from(parcelable)
-      val generator = ParcelableContentGenerator(spec, ValueAdapterFactory.from(factory, spec))
+    createSink(output).use { sink ->
+      findAutoParcelableClasses(listOf(input)).forEach { classMirror ->
+        val spec = AutoParcelableClassSpecFactory.from(classMirror)
+        val generator = ParcelableContentGenerator(spec, ValueAdapterFactory.from(factory, spec))
 
-      generator.generate(environment).forEach {
-        File(output, it.path).writeBytes(it.content)
-      }
-    }
-  }
-
-  fun cleanup(output: File) {
-    output.walkTopDown().forEach { file ->
-      if (file.isFile && file.endsWith("\$\$AutoCreator.class")) {
-        file.delete()
+        generator.generate(environment).forEach { content ->
+          sink.write(content.path, content.content)
+        }
       }
     }
   }
@@ -47,6 +45,16 @@ class SmugglerCompiler private constructor(
     }
   }
 
+  fun cleanup(output: File) {
+    if (output.exists()) {
+      createJanitor(output).cleanup()
+    }
+  }
+
+  override fun close() {
+    grip.close()
+  }
+
   private fun findAutoParcelableClasses(sources: Iterable<File>): Iterable<ClassMirror> {
     return grip.select(classes)
       .from(sources)
@@ -55,8 +63,86 @@ class SmugglerCompiler private constructor(
       .values
   }
 
-  override fun close() {
-    grip.close()
+  private fun createSink(file: File): Sink {
+    return if (file.isDirectory) {
+      DirectorySink(file)
+    } else {
+      JarSink(file)
+    }
+  }
+
+  private fun createJanitor(file: File): Janitor {
+    return if (file.isDirectory) {
+      DirectoryJanitor(file)
+    } else {
+      JarJanitor(file)
+    }
+  }
+
+  private interface Sink : Closeable {
+    fun write(path: String, content: ByteArray)
+  }
+
+  private interface Janitor {
+    fun cleanup()
+  }
+
+  private class DirectoryJanitor(
+    private val directory: File
+  ) : Janitor {
+    override fun cleanup() {
+      directory.walkTopDown().forEach { file ->
+        if (file.isFile && file.endsWith("\$\$AutoCreator.class")) {
+          file.delete()
+        }
+      }
+    }
+  }
+
+  private class JarJanitor(
+    private val file: File
+  ) : Janitor {
+    override fun cleanup() {
+      val entries = ZipFile(file).use { zipFile ->
+        zipFile.entries().toList().map { zipEntry ->
+          zipEntry.name
+        }
+      }
+
+      FileSystems.newFileSystem(file.toPath(), null).use { fileSystem ->
+        entries.forEach { entry ->
+          if (entry.endsWith("\$\$AutoCreator.class")) {
+            Files.delete(fileSystem.getPath(entry))
+          }
+        }
+      }
+    }
+  }
+
+  private class DirectorySink(
+    private val directory: File
+  ) : Sink {
+    override fun write(path: String, content: ByteArray) {
+      File(directory, path).writeBytes(content)
+    }
+
+    override fun close() {
+      // nothing to do
+    }
+  }
+
+  private class JarSink(
+    private val file: File
+  ) : Sink {
+    private val fileSystem = FileSystems.newFileSystem(file.toPath(), null)
+
+    override fun write(path: String, content: ByteArray) {
+      fileSystem.getPath(path).writeBytes(content)
+    }
+
+    override fun close() {
+      fileSystem.close()
+    }
   }
 
   companion object {

--- a/smuggler-plugin/src/main/java/com/joom/smuggler/plugin/SmugglerConfiguration.kt
+++ b/smuggler-plugin/src/main/java/com/joom/smuggler/plugin/SmugglerConfiguration.kt
@@ -1,0 +1,46 @@
+package com.joom.smuggler.plugin
+
+import com.android.build.api.transform.QualifiedContent
+import java.util.EnumSet
+
+data class SmugglerConfiguration(
+  val scopes: Set<QualifiedContent.Scope>,
+  val referencedScopes: Set<QualifiedContent.Scope>,
+  val verifyNoUnprocessedClasses: Boolean
+)
+
+object SmugglerConfigurationFactory {
+  fun createConfigurationForCurrentProject(): SmugglerConfiguration {
+    return SmugglerConfiguration(
+      scopes = EnumSet.of(
+        QualifiedContent.Scope.PROJECT
+      ),
+
+      referencedScopes = EnumSet.of(
+        QualifiedContent.Scope.TESTED_CODE,
+        QualifiedContent.Scope.SUB_PROJECTS,
+        QualifiedContent.Scope.EXTERNAL_LIBRARIES,
+        QualifiedContent.Scope.PROVIDED_ONLY
+      ),
+
+      verifyNoUnprocessedClasses = true
+    )
+  }
+
+  fun createConfigurationForCurrentProjectAndSubprojects(): SmugglerConfiguration {
+    return SmugglerConfiguration(
+      scopes = EnumSet.of(
+        QualifiedContent.Scope.PROJECT,
+        QualifiedContent.Scope.SUB_PROJECTS
+      ),
+
+      referencedScopes = EnumSet.of(
+        QualifiedContent.Scope.TESTED_CODE,
+        QualifiedContent.Scope.EXTERNAL_LIBRARIES,
+        QualifiedContent.Scope.PROVIDED_ONLY
+      ),
+
+      verifyNoUnprocessedClasses = false
+    )
+  }
+}

--- a/smuggler-plugin/src/main/java/com/joom/smuggler/plugin/SmugglerPlugin.kt
+++ b/smuggler-plugin/src/main/java/com/joom/smuggler/plugin/SmugglerPlugin.kt
@@ -37,7 +37,7 @@ open class SmugglerPlugin : Plugin<Project> {
     val android = findAndroidExtension(project)
 
     when (computeMode(project)) {
-      SmugglerMode.NOOP -> {
+      SmugglerMode.NO_OP -> {
         // nothing to do here
       }
 
@@ -94,6 +94,6 @@ open class SmugglerPlugin : Plugin<Project> {
   private enum class SmugglerMode(val value: String) {
     CURRENT_PROJECT_ONLY("currentProjectOnly"),
     CURRENT_PROJECT_WITH_SUBPROJECTS("currentProjectWithSubprojects"),
-    NOOP("noop")
+    NO_OP("noOp")
   }
 }

--- a/smuggler-plugin/src/main/java/com/joom/smuggler/plugin/SmugglerTransform.kt
+++ b/smuggler-plugin/src/main/java/com/joom/smuggler/plugin/SmugglerTransform.kt
@@ -17,49 +17,41 @@ import java.util.EnumSet
 
 class SmugglerTransform(
   private val android: BaseExtension,
-  private val extension: SmugglerExtension
+  private val extension: SmugglerExtension,
+  private val configuration: SmugglerConfiguration
 ) : Transform() {
   override fun transform(invocation: TransformInvocation) {
-    val transformSet = TransformSet.create(invocation, android.bootClasspath)
-    val transformClasspath = transformSet.getClasspath()
+    val transformSet = computePreparedTransformSet(invocation)
+    val adapters = computeClasspathForAdapters(transformSet, invocation)
 
-    if (!invocation.isIncremental) {
-      invocation.outputProvider.deleteAll()
-    }
+    SmugglerCompiler.create(transformSet.getClasspath(), adapters).use { compiler ->
+      computeTransformUnitGroups(transformSet)
+        .filter { it.containsModifiedUnits() }
+        .parallelStream()
+        .forEach { transformGroup ->
+          if (invocation.isIncremental) {
+            compiler.cleanup(transformGroup.output)
+          }
 
-    transformSet.copyInputsToOutputs()
-
-    val adapters = computeClasspathForAdapters(invocation)
-    val compiler = SmugglerCompiler.create(transformClasspath, adapters)
-
-    compiler.use {
-      for (unit in transformSet.units) {
-        compiler.cleanup(unit.output)
-      }
-
-      for (unit in transformSet.units) {
-        if (unit.changes.status != TransformUnit.Status.REMOVED) {
-          compiler.compile(unit.input, unit.output)
+          transformGroup.units.forEach { transformUnit ->
+            if (transformUnit.changes.status != TransformUnit.Status.REMOVED) {
+              compiler.compile(transformUnit.input, transformUnit.output)
+            }
+          }
         }
-      }
 
-      verifyNoUnprocessedClasses(invocation, compiler)
+      if (configuration.verifyNoUnprocessedClasses) {
+        verifyNoUnprocessedClasses(invocation, compiler)
+      }
     }
   }
 
   override fun getScopes(): MutableSet<Scope> {
-    return EnumSet.of(
-      Scope.PROJECT
-    )
+    return configuration.scopes.toMutableSet()
   }
 
   override fun getReferencedScopes(): MutableSet<Scope> {
-    return EnumSet.of(
-      Scope.TESTED_CODE,
-      Scope.SUB_PROJECTS,
-      Scope.EXTERNAL_LIBRARIES,
-      Scope.PROVIDED_ONLY
-    )
+    return configuration.referencedScopes.toMutableSet()
   }
 
   override fun getInputTypes(): Set<QualifiedContent.ContentType> {
@@ -131,20 +123,22 @@ class SmugglerTransform(
     return result
   }
 
-  private fun computeClasspathForAdapters(invocation: TransformInvocation): Collection<File> {
-    val transformSet = TransformSet.create(invocation, emptyList())
+  private fun computeClasspathForAdapters(
+    transformSet: TransformSet,
+    transformInvocation: TransformInvocation
+  ): Collection<File> {
     val classpath = transformSet.getClasspath().toSet()
 
     val scopes = setOf(Scope.PROJECT, Scope.SUB_PROJECTS)
     val contents = ArrayList<QualifiedContent>()
     val result = ArrayList<File>()
 
-    for (input in invocation.referencedInputs) {
+    for (input in transformInvocation.referencedInputs) {
       contents.addAll(input.directoryInputs)
       contents.addAll(input.jarInputs)
     }
 
-    for (input in invocation.inputs) {
+    for (input in transformInvocation.inputs) {
       contents.addAll(input.directoryInputs)
       contents.addAll(input.jarInputs)
     }
@@ -157,4 +151,38 @@ class SmugglerTransform(
 
     return result
   }
+
+  private fun computePreparedTransformSet(transformInvocation: TransformInvocation): TransformSet {
+    val transformSet = TransformSet.create(transformInvocation, android.bootClasspath)
+
+    if (!transformInvocation.isIncremental) {
+      transformInvocation.outputProvider.deleteAll()
+    }
+
+    transformSet.copyInputsToOutputs()
+    return transformSet
+  }
+
+  private fun computeTransformUnitGroups(transformSet: TransformSet): List<TransformUnitGroup> {
+    return transformSet.units
+      .groupBy { it.output }
+      .map { TransformUnitGroup(it.key, it.value) }
+  }
+
+  private fun TransformUnitGroup.containsModifiedUnits(): Boolean {
+    return units.any { unit ->
+      when (unit.changes.status) {
+        TransformUnit.Status.UNKNOWN -> true
+        TransformUnit.Status.ADDED -> true
+        TransformUnit.Status.CHANGED -> true
+        TransformUnit.Status.REMOVED -> true
+        TransformUnit.Status.UNCHANGED -> false
+      }
+    }
+  }
+
+  private data class TransformUnitGroup(
+    val output: File,
+    val units: List<TransformUnit>
+  )
 }

--- a/smuggler-plugin/src/main/java/com/joom/smuggler/plugin/SmugglerTransform.kt
+++ b/smuggler-plugin/src/main/java/com/joom/smuggler/plugin/SmugglerTransform.kt
@@ -27,7 +27,6 @@ class SmugglerTransform(
     SmugglerCompiler.create(transformSet.getClasspath(), adapters).use { compiler ->
       computeTransformUnitGroups(transformSet)
         .filter { it.containsModifiedUnits() }
-        .parallelStream()
         .forEach { transformGroup ->
           if (invocation.isIncremental) {
             compiler.cleanup(transformGroup.output)

--- a/smuggler-plugin/src/main/java/com/joom/smuggler/plugin/SmugglerTransform.kt
+++ b/smuggler-plugin/src/main/java/com/joom/smuggler/plugin/SmugglerTransform.kt
@@ -32,17 +32,19 @@ class SmugglerTransform(
     val adapters = computeClasspathForAdapters(invocation)
     val compiler = SmugglerCompiler.create(transformClasspath, adapters)
 
-    for (unit in transformSet.units) {
-      compiler.cleanup(unit.output)
-    }
-
-    for (unit in transformSet.units) {
-      if (unit.changes.status != TransformUnit.Status.REMOVED) {
-        compiler.compile(unit.input, unit.output)
+    compiler.use {
+      for (unit in transformSet.units) {
+        compiler.cleanup(unit.output)
       }
-    }
 
-    verifyNoUnprocessedClasses(invocation, compiler)
+      for (unit in transformSet.units) {
+        if (unit.changes.status != TransformUnit.Status.REMOVED) {
+          compiler.compile(unit.input, unit.output)
+        }
+      }
+
+      verifyNoUnprocessedClasses(invocation, compiler)
+    }
   }
 
   override fun getScopes(): MutableSet<Scope> {


### PR DESCRIPTION
Тут два полезных изменения - одно простое, а другое посложнее. 

## Простое изменение
Теперь `SmugglerCompiler` стал `Closeable`. Нужно это потому что он внутри себя создает инстанс `Grip`, который тоже `Closeable` и который мы до этого никогда не закрывали. Вроде из-за этого могли утекать только файловые дескрипторы, что в целом не очень страшно, но возможно были и какие-нибудь другие последствия.

## Изменение посложнее
Тут, пожалуй, стоит рассказать, как у нас Smuggler работает прямо сейчас. В каждом модуле, где мы хотим использовать `AutoParcelable` интерфейс, мы должны добавить плагин `com.joom.smuggler`. Это плагин добавляет в пайплайн `SmugglerTransform`, которая внутри модуля патчит байткод и добавлять нужные штуки для работы `Parcelable`. 

У такого подхода есть свои плюсы - каждый из модулей на выходе получается абсолютно работоспособным и такие модули можно подключать в другие проекты, которые сами по себе `Smuggler` не используют. На самом деле это уже используется у нас же в репозитории - некоторые из `common` модулей используют `Smuggler`, а дальше эти же модули используются в `JoomPay`, который вместо `Smuggler` использует дефолтный `Parcelize`.

Однако у этого подхода есть и минусы - `SmugglerTransform` применяется для каждого из модуля и внутри модуля она парсит свои собственные классы + классы зависимостей, в том числе `android.jar`. По мере роста количества модулей мы все чаще и чаще будем парсить одни и те же классы + наличие трансформы при водит к дополнительному IO, т.к. в каждом из модулей нужно скопировать все `*.class` и `*.jar` файлы в output дериктория.

Альтернативный подход - это не запускать трансформу в подмодулях и делать весь процессинг только в модуле приложения. Это позволяет избежать повторного парсинга классов и их копирование тоже происходит всего-лишь один раз. Из минусов - `AutoParcelable` классы из модулей по дефолту работать не будут, поэтому `smuggler` нужно дополнительно еще включать на уровне каждого из приложения.
